### PR TITLE
Ingore interfaces for the default gateway

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -298,6 +298,7 @@ func (np *NetworkDriver) PublishResources(ctx context.Context) {
 	}
 
 	gceInterfaces := getInstanceNetworkInterfaces(ctx)
+	gwInterfaces := getDefaultGwInterfaces()
 
 	for {
 		err := rateLimiter.Wait(ctx)
@@ -312,7 +313,10 @@ func (np *NetworkDriver) PublishResources(ctx context.Context) {
 		}
 		for _, iface := range ifaces {
 			klog.V(7).InfoS("Checking network interface", "name", iface.Name)
-
+			if gwInterfaces.Has(iface.Name) {
+				klog.V(4).Infof("iface %s is an uplink interface", iface.Name)
+				continue
+			}
 			// TODO: interface names can be invalid with the object name
 			if len(validation.IsDNS1123Label(iface.Name)) > 0 {
 				klog.V(2).Infof("iface %s does not pass validation", iface.Name)

--- a/pkg/driver/routes.go
+++ b/pkg/driver/routes.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"log"
+
+	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func getDefaultGwInterfaces() sets.Set[string] {
+	interfaces := sets.Set[string]{}
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+	if err != nil {
+		return interfaces
+	}
+
+	for _, r := range routes {
+		// no multipath
+		if len(r.MultiPath) == 0 {
+			if r.Gw == nil {
+				continue
+			}
+			intfLink, err := netlink.LinkByIndex(r.LinkIndex)
+			if err != nil {
+				log.Printf("Failed to get interface link for route %v : %v", r, err)
+				continue
+			}
+			interfaces.Insert(intfLink.Attrs().Name)
+		}
+
+		for _, nh := range r.MultiPath {
+			if nh.Gw == nil {
+				continue
+			}
+			intfLink, err := netlink.LinkByIndex(r.LinkIndex)
+			if err != nil {
+				log.Printf("Failed to get interface link for route %v : %v", r, err)
+				continue
+			}
+			interfaces.Insert(intfLink.Attrs().Name)
+		}
+	}
+	return interfaces
+}


### PR DESCRIPTION
The interfaces with the default gateway provide connectivity to the node, if these interfaces are moved into a pod they will leave the node without connectivity