### PR TITLE
add build version

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"sync/atomic"
 
 	"github.com/google/dranet/pkg/driver"
@@ -63,6 +64,7 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
+	printVersion()
 	flag.VisitAll(func(f *flag.Flag) {
 		klog.Infof("FLAG: --%s=%q", f.Name, f.Value)
 	})
@@ -133,5 +135,21 @@ func main() {
 		cancel()
 	case <-ctx.Done():
 	}
+}
 
+func printVersion() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	var vcsRevision, vcsTime string
+	for _, f := range info.Settings {
+		switch f.Key {
+		case "vcs.revision":
+			vcsRevision = f.Value
+		case "vcs.time":
+			vcsTime = f.Value
+		}
+	}
+	klog.Infof("dranet go %s build: %s time: %s", info.GoVersion, vcsRevision, vcsTime)
 }


### PR DESCRIPTION
Useful for troubleshooting in prod, golang version and git info are logged at startup

```
kubectl -n kube-system logs dranet-897fq
Defaulted container "dranet" out of: dranet, enable-nri (init)
I1215 18:28:59.834853   20695 app.go:154] dranet go go1.23.4 build: 6bb54c3868e81b1d7e2a490dbdd13e538de9f1da time: 2024-12-14T16:53:20Z
I1215 18:28:59.834937   20695 app.go:69] FLAG: --add_dir_header="false"
I1215 18:28:59.834948   20695 app.go:69] FLAG: --alsologtostderr="false"
I1215 18:28:59.834950   20695 app.go:69] FLAG: --bind-address=":9177"
I1215 18:28:59.834953   20695 app.go:69] FLAG: --hostname-override=""
I1215 18:28:59.834956   20695 app.go:69] FLAG: --kubeconfig=""
I1215 18:28:59.834957   20695 app.go:69] FLAG: --log_backtrace_at=":0"
I1215 18:28:59.834962   20695 app.go:69] FLAG: --log_dir=""
I1215 18:28:59.834965   20695 app.go:69] FLAG: --log_file=""
I1215 18:28:59.834967   20695 app.go:69] FLAG: --log_file_max_size="1800"
I1215 18:28:59.834969   20695 app.go:69] FLAG: --logtostderr="true"
I1215 18:28:59.834971   20695 app.go:69] FLAG: --one_output="false"
I1215 18:28:59.834973   20695 app.go:69] FLAG: --skip_headers="false"
I1215 18:28:59.834975   20695 app.go:69] FLAG: --skip_log_headers="false"
I1215 18:28:59.834976   20695 app.go:69] FLAG: --stderrthreshold="2"
I1215 18:28:59.834979   20695 app.go:69] FLAG: --v="4"
I1215 18:28:59.834982   20695 app.go:69] FLAG: --vmodule=""
I1215 18:28:59.835229   20695 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I1215 18:28:59.835241   20695 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I1215 18:28:59.835247   20695 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I1215 18:28:59.835255   20695 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I1215 18:28:59.835745   20695 draplugin.go:319] "Starting"
I1215 18:28:59.835899   20695 nonblockinggrpcserver.go:111] "GRPC server starte
```