### PR TITLE
use an agnostic driver name

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	driverName = "dranet.gke.io"
+	driverName = "dra.net"
 )
 
 var (

--- a/examples/deviceclass.yaml
+++ b/examples/deviceclass.yaml
@@ -15,9 +15,9 @@
 apiVersion: resource.k8s.io/v1beta1
 kind: DeviceClass
 metadata:
-  name: dranet.gke.io
+  name: dra.net
 spec:
   selectors:
     - cel:
-        expression: device.driver == "dranet.gke.io"
+        expression: device.driver == "dra.net"
 

--- a/examples/resourceclaim.yaml
+++ b/examples/resourceclaim.yaml
@@ -20,13 +20,13 @@ spec:
   devices:
     requests:
     - name: req-dummy
-      deviceClassName: dranet.gke.io
+      deviceClassName: dra.net
       selectors:
         - cel:
-            expression: device.attributes["dranet.gke.io"].type == "dummy"
+            expression: device.attributes["dra.net"].type == "dummy"
     config:
     - opaque:
-        driver: dranet.gke.io
+        driver: dra.net
         parameters:
           newName: "eth99"
           address: "192.168.2.2"

--- a/examples/resourceclaimtemplate.yaml
+++ b/examples/resourceclaimtemplate.yaml
@@ -21,7 +21,7 @@ spec:
     devices:
       requests:
       - name: req-dummy-template
-        deviceClassName: dranet.gke.io
+        deviceClassName: dra.net
 ---
 apiVersion: v1
 kind: Pod

--- a/site/content/docs/quick-start.md
+++ b/site/content/docs/quick-start.md
@@ -106,9 +106,9 @@ apiVersion: resource.k8s.io/v1beta1
 kind: ResourceSlice
 metadata:
   creationTimestamp: "2024-12-15T23:41:51Z"
-  generateName: gke-aojea-dra-multi-nic-985b8c20-jg5l-dranet.gke.io-
+  generateName: gke-aojea-dra-multi-nic-985b8c20-jg5l-dra.net-
   generation: 1
-  name: gke-aojea-dra-multi-nic-985b8c20-jg5l-dranet.gke.io-8nq9c
+  name: gke-aojea-dra-multi-nic-985b8c20-jg5l-dra.net-8nq9c
   ownerReferences:
   - apiVersion: v1
     controller: true
@@ -257,12 +257,12 @@ metadata:
 spec:
   selectors:
     - cel:
-        expression: device.driver == "dranet.gke.io"
+        expression: device.driver == "dra.net"
     - cel:
-        expression: has(device.attributes["dranet.gke.io"].cloud_network) 
+        expression: has(device.attributes["dra.net"].cloud_network) 
   config:
   - opaque:
-      driver: dranet.gke.io
+      driver: dra.net
       parameters:
         nccl: "true"
 ```
@@ -281,7 +281,7 @@ spec:
       deviceClassName: dranet-cloud
       selectors:
         - cel:
-            expression: device.attributes["dranet.gke.io"].cloud_network == "projects/961828715260/networks/aojea-dra-net-3"
+            expression: device.attributes["dra.net"].cloud_network == "projects/961828715260/networks/aojea-dra-net-3"
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
DRANET goal is to be agnostic and for general usage, so use a more neutral name for the driver