### PR TITLE
Normalized interfaces

### DIFF
--- a/pkg/apis/constants.go
+++ b/pkg/apis/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+const (
+	NetworkKind = "network"
+	RdmaKind    = "rdma"
+)

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/google/dranet/pkg/apis"
+	resourceapi "k8s.io/api/resource/v1beta1"
+	"k8s.io/utils/ptr"
+)
+
+func TestGetDeviceName(t *testing.T) {
+	type args struct {
+		device *resourceapi.Device
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "nil device",
+			args: args{device: nil},
+			want: "",
+		},
+		{
+			name: "nil basic",
+			args: args{device: &resourceapi.Device{Name: "test-dev"}},
+			want: "test-dev",
+		},
+		{
+			name: "nil attributes",
+			args: args{device: &resourceapi.Device{Name: "test-dev", Basic: &resourceapi.BasicDevice{}}},
+			want: "test-dev",
+		},
+		{
+			name: "missing kind attribute",
+			args: args{device: &resourceapi.Device{
+				Name: "test-dev",
+				Basic: &resourceapi.BasicDevice{
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
+				},
+			}},
+			want: "test-dev",
+		},
+		{
+			name: "kind attribute not a string",
+			args: args{device: &resourceapi.Device{
+				Name: "test-dev",
+				Basic: &resourceapi.BasicDevice{
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"dra.net/kind": {BoolValue: ptr.To(true)},
+					},
+				},
+			}},
+			want: "test-dev",
+		},
+		{
+			name: "network kind, ifName present",
+			args: args{device: &resourceapi.Device{
+				Name: "normalized-eth0",
+				Basic: &resourceapi.BasicDevice{
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"dra.net/kind":   {StringValue: ptr.To(apis.NetworkKind)},
+						"dra.net/ifName": {StringValue: ptr.To("eth0")},
+					},
+				},
+			}},
+			want: "eth0",
+		},
+		{
+			name: "network kind, ifName missing",
+			args: args{device: &resourceapi.Device{
+				Name: "normalized-eth0",
+				Basic: &resourceapi.BasicDevice{
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"dra.net/kind": {StringValue: ptr.To(apis.NetworkKind)},
+					},
+				},
+			}},
+			want: "normalized-eth0",
+		},
+		{
+			name: "network kind, ifName not a string",
+			args: args{device: &resourceapi.Device{
+				Name: "normalized-eth0",
+				Basic: &resourceapi.BasicDevice{
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"dra.net/kind":   {StringValue: ptr.To(apis.NetworkKind)},
+						"dra.net/ifName": {IntValue: ptr.To[int64](123)},
+					},
+				},
+			}},
+			want: "normalized-eth0",
+		},
+		{
+			name: "rdma kind, rdmaDevName present",
+			args: args{device: &resourceapi.Device{
+				Name: "normalized-rdma0",
+				Basic: &resourceapi.BasicDevice{
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"dra.net/kind":        {StringValue: ptr.To(apis.RdmaKind)},
+						"dra.net/rdmaDevName": {StringValue: ptr.To("mlx5_0")},
+					},
+				},
+			}},
+			want: "mlx5_0",
+		},
+		{
+			name: "rdma kind, rdmaDevName missing",
+			args: args{device: &resourceapi.Device{
+				Name: "normalized-rdma0",
+				Basic: &resourceapi.BasicDevice{
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"dra.net/kind": {StringValue: ptr.To(apis.RdmaKind)},
+					},
+				},
+			}},
+			want: "normalized-rdma0",
+		},
+		{
+			name: "rdma kind, rdmaDevName not a string",
+			args: args{device: &resourceapi.Device{
+				Name: "normalized-rdma0",
+				Basic: &resourceapi.BasicDevice{
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"dra.net/kind":        {StringValue: ptr.To(apis.RdmaKind)},
+						"dra.net/rdmaDevName": {BoolValue: ptr.To(false)},
+					},
+				},
+			}},
+			want: "normalized-rdma0",
+		},
+		{
+			name: "unknown kind",
+			args: args{device: &resourceapi.Device{Name: "test-dev", Basic: &resourceapi.BasicDevice{Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"dra.net/kind": {StringValue: ptr.To("unknown")}}}}},
+			want: "test-dev",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getDeviceName(tt.args.device); got != tt.want {
+				t.Errorf("GetDeviceName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/Mellanox/rdmamap"
+	"github.com/google/dranet/pkg/apis"
 	"github.com/google/dranet/pkg/cloudprovider"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -37,9 +38,6 @@ import (
 )
 
 const (
-	networkKind = "network"
-	rdmaKind    = "rdma"
-
 	// database poll period
 	minInterval = 5 * time.Second
 	maxInterval = 1 * time.Minute
@@ -57,11 +55,6 @@ type DB struct {
 
 	rateLimiter   *rate.Limiter
 	notifications chan []resourceapi.Device
-}
-
-type Device struct {
-	Kind string
-	Name string
 }
 
 func New() *DB {
@@ -213,7 +206,7 @@ func (db *DB) netdevToDRAdev(ifName string) (*resourceapi.Device, error) {
 		klog.V(2).Infof("normalizing iface %s name", ifName)
 		device.Name = "normalized-" + dns1123LabelNonValid.ReplaceAllString(ifName, "-")
 	}
-	device.Basic.Attributes["dra.net/kind"] = resourceapi.DeviceAttribute{StringValue: ptr.To(networkKind)}
+	device.Basic.Attributes["dra.net/kind"] = resourceapi.DeviceAttribute{StringValue: ptr.To(apis.NetworkKind)}
 	device.Basic.Attributes["dra.net/ifName"] = resourceapi.DeviceAttribute{StringValue: &ifName}
 	link, err := netlink.LinkByName(ifName)
 	if err != nil {
@@ -301,7 +294,7 @@ func (db *DB) rdmaToDRAdev(ifName string) (*resourceapi.Device, error) {
 		device.Name = "norm-" + dns1123LabelNonValid.ReplaceAllString(ifName, "-")
 	}
 
-	device.Basic.Attributes["dra.net/kind"] = resourceapi.DeviceAttribute{StringValue: ptr.To(rdmaKind)}
+	device.Basic.Attributes["dra.net/kind"] = resourceapi.DeviceAttribute{StringValue: ptr.To(apis.RdmaKind)}
 	device.Basic.Attributes["dra.net/rdmaDevName"] = resourceapi.DeviceAttribute{StringValue: &ifName}
 	device.Basic.Attributes["dra.net/rdma"] = resourceapi.DeviceAttribute{BoolValue: ptr.To(true)}
 	link, err := netlink.RdmaLinkByName(ifName)

--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -19,6 +19,24 @@
 }
 
 
+@test "dummy interface with IP addresses ResourceClaim and normalized name" {
+  docker exec "$CLUSTER_NAME"-worker bash -c "ip link add mlx5_6 type dummy"
+  docker exec "$CLUSTER_NAME"-worker bash -c "ip link set up dev mlx5_6"
+
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../examples/deviceclass.yaml
+  kubectl apply -f "$BATS_TEST_DIRNAME"/../examples/resourceclaim.yaml
+  kubectl wait --timeout=2m --for=condition=ready pods -l app=pod
+  run kubectl exec pod1 -- ip addr show eth99
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"169.254.169.13"* ]]
+  run kubectl get resourceclaims dummy-interface-static-ip  -o=jsonpath='{.status.devices[0].networkData.ips[*]}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"169.254.169.13"* ]]
+
+  kubectl delete -f "$BATS_TEST_DIRNAME"/../examples/deviceclass.yaml
+  kubectl delete -f "$BATS_TEST_DIRNAME"/../examples/resourceclaim.yaml
+}
+
 @test "dummy interface with IP addresses ResourceClaimTemplate" {
   docker exec "$CLUSTER_NAME"-worker2 bash -c "ip link add dummy1 type dummy"
   docker exec "$CLUSTER_NAME"-worker2 bash -c "ip addr add 169.254.169.14/32 dev dummy1"


### PR DESCRIPTION
   deal with normalized interfaces

    Kubernetes API validation does not allow to use some valid interface
    names as Device names, so we need to normalize the name and we use an
    attribute to export the real name.

    The driver keeps a local cache for the exported devices so can sneek
    into the cache to get the ifname if needed.

