### PR TITLE
Fix typo in developer guide

### DIFF
--- a/site/content/docs/contributing/developer-guide.md
+++ b/site/content/docs/contributing/developer-guide.md
@@ -85,9 +85,6 @@ gke-tpu-de8b9feb-kgdj / #
 
 If you want to upload some binary, per example `bpftrace` or `pwru` , you can use the streaming capabilities for that:
 
-```
-
-
 ## Troubleshooting
 
 To get the list of `dranet` Pods use the label:


### PR DESCRIPTION
Remove unneeded quoted text that messes up the formatting