### PR TITLE
Fix status updates only adding one device per claim

### DIFF
--- a/examples/resourceclaimtemplate_double.yaml
+++ b/examples/resourceclaimtemplate_double.yaml
@@ -1,0 +1,65 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: resource.k8s.io/v1beta1
+kind: DeviceClass
+metadata:
+  name: multinic
+spec:
+  selectors:
+    - cel:
+        expression: device.driver == "dra.net"
+---
+apiVersion: resource.k8s.io/v1beta1
+kind: ResourceClaimTemplate
+metadata:
+  name: phy-interfaces-template
+spec:
+  spec:
+    devices:
+      requests:
+      - name: phy-interfaces-template
+        count: 2
+        deviceClassName: multinic
+        selectors:
+        - cel:
+            expression: device.attributes["dra.net"].ifName == "dummy6" || device.attributes["dra.net"].ifName == "dummy7"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server-deployment
+  labels:
+    app: MyApp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: MyApp
+  template:
+    metadata:
+      labels:
+        app: MyApp
+    spec:
+      resourceClaims:
+      - name: phy-interfaces
+        resourceClaimTemplateName: phy-interfaces-template
+      containers:
+      - name: agnhost
+        image: registry.k8s.io/e2e-test-images/agnhost:2.54
+        args:
+          - netexec
+          - --http-port=80
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
Due to SSA tracking owners, we need to do a batch update of status at the end of our NRI loop. Fix this by tracking all status updates needed and doing a batch update at the end.

Fixes #117 