### PR TITLE
interface dhcp configuration

### DIFF
--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -41,6 +41,10 @@ type InterfaceConfig struct {
 	// to be assigned to the interface.
 	Addresses []string `json:"addresses,omitempty"`
 
+	// DHCP, if true, indicates that the interface should be configured via DHCP.
+	// This is mutually exclusive with the 'addresses' field.
+	DHCP *bool `json:"dhcp,omitempty"`
+
 	// MTU is the Maximum Transmission Unit for the interface.
 	MTU *int32 `json:"mtu,omitempty"`
 

--- a/pkg/apis/validation.go
+++ b/pkg/apis/validation.go
@@ -128,6 +128,10 @@ func validateInterfaceConfig(cfg *InterfaceConfig, fieldPath string) (allErrors 
 		}
 	}
 
+	if cfg.DHCP != nil && *cfg.DHCP && len(cfg.Addresses) > 0 {
+		allErrors = append(allErrors, fmt.Errorf("%s: dhcp and addresses are mutually exclusive", fieldPath))
+	}
+
 	if cfg.MTU != nil {
 		if *cfg.MTU < MinMTU {
 			allErrors = append(allErrors, fmt.Errorf("%s.mtu: must be at least %d, got %d", fieldPath, MinMTU, *cfg.MTU))

--- a/pkg/apis/validation_test.go
+++ b/pkg/apis/validation_test.go
@@ -254,6 +254,25 @@ func TestValidateInterfaceConfig(t *testing.T) {
 			errCount:  1,
 		},
 		{
+			name:      "valid with dhcp",
+			cfg:       &InterfaceConfig{Name: "eth0", DHCP: ptr.To(true)},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
+			name:      "invalid with dhcp and addresses",
+			cfg:       &InterfaceConfig{Name: "eth0", DHCP: ptr.To(true), Addresses: []string{"10.0.0.1/24"}},
+			fieldPath: "iface",
+			expectErr: true,
+			errCount:  1,
+		},
+		{
+			name:      "valid with dhcp false and addresses",
+			cfg:       &InterfaceConfig{Name: "eth0", DHCP: ptr.To(false), Addresses: []string{"10.0.0.1/24"}},
+			fieldPath: "iface",
+			expectErr: false,
+		},
+		{
 			name:      "multiple errors",
 			cfg:       &InterfaceConfig{Name: "eth/0", Addresses: []string{"badip"}, MTU: ptr.To[int32](0)},
 			fieldPath: "iface",

--- a/pkg/driver/dhcp.go
+++ b/pkg/driver/dhcp.go
@@ -27,7 +27,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func getDHCP(ifName string) (ip string, routes []apis.RouteConfig, err error) {
+func getDHCP(ctx context.Context, ifName string) (ip string, routes []apis.RouteConfig, err error) {
 	link, err := netlink.LinkByName(ifName)
 	if err != nil {
 		return "", nil, err
@@ -43,7 +43,7 @@ func getDHCP(ifName string) (ip string, routes []apis.RouteConfig, err error) {
 	}
 	defer dhclient.Close()
 
-	lease, err := dhclient.Request(context.Background())
+	lease, err := dhclient.Request(ctx)
 	if err != nil {
 		return "", nil, fmt.Errorf("fail to obtain DHCP lease on interface %s  up: %v", ifName, err)
 	}


### PR DESCRIPTION
dhcp should be an opt-in option because running it can cause delays on pod startup on environments that don't have dhcp enabled.

Change-Id: I2905788c261583d86a5701576c2e61a245138c02