### PR TITLE
fix: Ignore devices not managed by DraNet in ResourceClaim

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -125,6 +125,16 @@ func (np *NetworkDriver) prepareResourceClaim(ctx context.Context, claim *resour
 	var errorList []error
 	charDevices := sets.New[string]()
 	for _, result := range claim.Status.Allocation.Devices.Results {
+		// A single ResourceClaim can have devices managed by distinct DRA
+		// drivers. One common use case for this is device topology alignment
+		// (think NIC and GPU alignment). In such cases, we should ignore the
+		// devices which are not managed by our driver.
+		//
+		// TODO: Test running a different driver alongside DraNet in e2e. This
+		//   requires an easy way to spin up a mock DRA driver.
+		if result.Driver != np.driverName {
+			continue
+		}
 		requestName := result.Request
 		netconf := apis.NetworkConfig{}
 		for _, config := range claim.Status.Allocation.Devices.Config {


### PR DESCRIPTION
This should help enable use cases involving device topology alignment.

Currently, we fail to process ResourceClaims that have devices from distinct drivers like the example below, since we don't recognize the `customgpu0` device.

```
apiVersion: resource.k8s.io/v1beta1
kind: ResourceClaim
metadata:
  name: my-claim
spec:
  devices:
    constraints:
    - matchAttribute: resource.kubernetes.io/pcieRoot
      requests:
      - nic-request
      - gpu-request
    requests:
    - allocationMode: ExactCount
      count: 1
      deviceClassName: dranet-cloud
      name: nic-request
    - allocationMode: ExactCount
      count: 1
      deviceClassName: gpu.nvidia.com
      name: gpu-request
status:
  allocation:
    devices:
      results:
      - adminAccess: null
        device: eth1
        driver: dra.net
        pool: my-node
        request: nic-request
      - adminAccess: null
        device: customgpu0
        driver: gpu.nvidia.com
        pool: my-node
        request: gpu-request
```