### PR TITLE
fix: Delete singleton links if they are removed

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -57,6 +57,7 @@ type DB struct {
 
 	rateLimiter   *rate.Limiter
 	notifications chan []resourceapi.Device
+	hasDevices    bool
 }
 
 func New() *DB {
@@ -176,7 +177,8 @@ func (db *DB) Run(ctx context.Context) error {
 		}
 
 		klog.V(4).Infof("Found %d devices", len(devices))
-		if len(devices) > 0 {
+		if len(devices) > 0 || db.hasDevices {
+			db.hasDevices = len(devices) > 0
 			db.notifications <- devices
 		}
 		select {


### PR DESCRIPTION
Currently if a link is deleted as the last link the driver will never reconcile and leave it in the resource slice. Ensure that this does not happen since that could lead to bad assignments by the scheduler. Can easily replicate the issue by creating a cluster and adding then removing a link.

Fixes #155