### PR TITLE
support scheduling constraints with the nvidia-gpu-driver

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -285,8 +285,7 @@ func (db *DB) netdevToDRAdev(link netlink.Link) (*resourceapi.Device, error) {
 		addPCIAttributes(device.Basic, ifName, sysnetPath)
 	}
 
-	mac := link.Attrs().HardwareAddr.String()
-	for name, attribute := range getProviderAttributes(mac, db.instance) {
+	for name, attribute := range getProviderAttributes(link, db.instance) {
 		device.Basic.Attributes[name] = attribute
 	}
 


### PR DESCRIPTION
the nvidia gpu dra driver will publish the index attribute in GA

```
 - basic: attributes: architecture: string: Blackwell brand: string: Nvidia cudaComputeCapability: version: 10.0.0 cudaDriverVersion: version: 12.8.0 driverVersion: version: 570.133.20 index: int: 3 minor: int: 3 productName: string: NVIDIA B200 type: string: gpu uuid: string: GPU-e8c94a15-28dc-6a61-ea67-626f02d315f0 capacity: memory: value: 183359Mi name: gpu-3
```
GCE added a convention to name the network interfaces associated to the GPU index, so we can use it to define the same index attribute and this way being able to use the  `MatchAttribute` constraint, which relies on exact value matching.

Change-Id: Ie2ad4c9f90a091664141fb47a23abcf7f9990c68