### PR TITLE
fix: eBPF attribute should be false when there are no programs

### DIFF
--- a/pkg/inventory/net.go
+++ b/pkg/inventory/net.go
@@ -97,7 +97,7 @@ func getTcxFilters(device netlink.Link) ([]string, bool) {
 			Target: int(device.Attrs().Index),
 			Attach: attach,
 		})
-		if err != nil {
+		if err != nil || result == nil || len(result.Programs) == 0 {
 			continue
 		}
 

--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -14,9 +14,9 @@ teardown() {
 setup_bpf_device() {
   docker cp "$BATS_TEST_DIRNAME"/dummy_bpf.o "$CLUSTER_NAME"-worker2:/dummy_bpf.o
   docker exec "$CLUSTER_NAME"-worker2 bash -c "ip link add dummy0 type dummy"
-  docker exec "$CLUSTER_NAME"-worker2 bash -c "ip link set up dev dummy0"
   docker exec "$CLUSTER_NAME"-worker2 bash -c "tc qdisc add dev dummy0 clsact"
   docker exec "$CLUSTER_NAME"-worker2 bash -c "tc filter add dev dummy0 ingress bpf direct-action obj dummy_bpf.o sec classifier"
+  docker exec "$CLUSTER_NAME"-worker2 bash -c "ip link set up dev dummy0"
 }
 
 setup_tcx_filter() {


### PR DESCRIPTION
Currently, eBPF attribute is always set to true since `link.QueryPrograms` always returns as success. This leads to the program thinking that is has "some" BPF programs since the code does not check for an empty return value.

This eventually trickles down to failures in "validate bpf filter attributes". The attribute is always true so we never wait and continue checking for the existence of `tcFilterNames` which may not yet have been updated by the driver.

Fixes https://github.com/google/dranet/issues/136