### PR TITLE
fix: GCE Provider attributes which don't rely on MAC should always be published

### DIFF
--- a/pkg/inventory/cloud.go
+++ b/pkg/inventory/cloud.go
@@ -53,16 +53,12 @@ func getProviderAttributes(mac string, instance *cloudprovider.CloudInstance) ma
 		klog.Warningf("instance metadata is nil, cannot get provider attributes.")
 		return nil
 	}
-	if instance.Provider != cloudprovider.CloudProviderGCE {
+	switch instance.Provider {
+	case cloudprovider.CloudProviderGCE:
+		return gce.GetGCEAttributes(mac, instance)
+	default:
 		klog.Warningf("cloud provider %q is not supported", instance.Provider)
-		return nil
 	}
-	for _, cloudInterface := range instance.Interfaces {
-		if cloudInterface.Mac == mac {
-			return gce.GetGCEAttributes(cloudInterface.Network, instance.Topology)
-		}
-	}
-	klog.Warningf("no matching cloud interface found for mac %s", mac)
 	return nil
 }
 


### PR DESCRIPTION
At the moment, we fail to publish topology information which is not dependent on the existence of a MAC