### PR TITLE
fix: Use complete PCI Address in BDF format when using GetPCIeRootAttributeByPCIBusID

### DIFF
--- a/pkg/inventory/db.go
+++ b/pkg/inventory/db.go
@@ -326,7 +326,9 @@ func addPCIAttributes(device *resourceapi.Device, ifName string, path string) {
 }
 
 func setPciRootAttr(device *resourceapi.Device, address *pciAddress) error {
-	pcieRootAttr, err := deviceattribute.GetPCIeRootAttributeByPCIBusID(address.bus)
+	// TODO(#199): Investigate ways to test correctness of PCI attributes
+	// discovery e2e (like standard PCI root attribute)
+	pcieRootAttr, err := deviceattribute.GetPCIeRootAttributeByPCIBusID(address.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/inventory/sysfs.go
+++ b/pkg/inventory/sysfs.go
@@ -124,6 +124,13 @@ type pciAddress struct {
 	function string
 }
 
+func (a pciAddress) String() string {
+	if a.domain == "" {
+		return fmt.Sprintf("%s:%s.%s", a.bus, a.device, a.function)
+	}
+	return fmt.Sprintf("%s:%s:%s.%s", a.domain, a.bus, a.device, a.function)
+}
+
 // The PCI root is the root PCI device, derived from the
 // pciAddress of a device. Spec is defined from the DRA KEP.
 // https://github.com/kubernetes/enhancements/pull/5316


### PR DESCRIPTION
The function name is confusing and makes one think it only wants the "Bus", but actually it expects the complete BDF notation (which as I also just learned, is also sometimes called a bus)

Without this, the function will fail at https://github.com/kubernetes/dynamic-resource-allocation/blob/f977084efa0c474b35eb9ad3131cf04f1313a917/deviceattribute/pci_linux.go#L43