### PR TITLE
add cleanup functions with debug info on failure between tests

### DIFF
--- a/tests/manifests/resourceclaim_route.yaml
+++ b/tests/manifests/resourceclaim_route.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 apiVersion: resource.k8s.io/v1
-kind:  ResourceClaim
+kind: ResourceClaim
 metadata:
   name: dummy-interface-static-ip-route
 spec:

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -3,7 +3,7 @@
 set -eu
 
 function setup_suite {
-  export BATS_TEST_TIMEOUT=120
+  export BATS_TEST_TIMEOUT=150
   # Define the name of the kind cluster
   export CLUSTER_NAME="dranet-test-cluster"
   export IMAGE_NAME="ghcr.io/google/dranet"


### PR DESCRIPTION
- Added cleanup between tests
- Reduced kubectl wait timeout from 300 to 120 in 2 tests
- Increased BATS_TEST_TIMEOUT from 120 to 150
- Fixes part of #137 