### PR TITLE
Update kind yaml to use 1.34 in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.33.1
+  image: kindest/node:v1.34.0
 - role: worker
-  image: kindest/node:v1.33.1
+  image: kindest/node:v1.34.0
 - role: worker
-  image: kindest/node:v1.33.1
-featureGates:
-  # Enable the corresponding DRA feature gates
-  DynamicResourceAllocation: true
-  DRAResourceClaimDeviceStatus: true
-runtimeConfig:
-  api/beta : true
+  image: kindest/node:v1.34.0
 ```
 
 Then to create the cluster:

--- a/kind.yaml
+++ b/kind.yaml
@@ -15,7 +15,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0
+  image: kindest/node:v1.34.0@7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
   kubeadmConfigPatches:
   # Enable the corresponding version of the resource.k8s.io API
   - |
@@ -33,7 +33,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.34.0
+  image: kindest/node:v1.34.0@7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -41,7 +41,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.34.0
+  image: kindest/node:v1.34.0@7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration

--- a/kind.yaml
+++ b/kind.yaml
@@ -33,7 +33,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.33.1
+  image: kindest/node:v1.34.0
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -41,7 +41,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.33.1
+  image: kindest/node:v1.34.0
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration

--- a/kind.yaml
+++ b/kind.yaml
@@ -15,7 +15,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.33.1
+  image: kindest/node:v1.34.0
   kubeadmConfigPatches:
   # Enable the corresponding version of the resource.k8s.io API
   - |
@@ -48,9 +48,3 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         v: "5"
-featureGates:
-  # Enable the corresponding DRA feature gates
-  DynamicResourceAllocation: true
-  DRAResourceClaimDeviceStatus: true
-runtimeConfig:
-  api/beta : true


### PR DESCRIPTION
Missed in previous PR. We should update this now that 1.34 is released and DRA is GA.