### PR TITLE
test: Revert back to sleeping for 5 seconds between tests

### DIFF
--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -12,7 +12,13 @@ teardown() {
   cleanup_k8s_resources
   cleanup_dummy_interfaces
   cleanup_bpf_programs
-  sleep 2
+  # The driver is rate limited to updates with interval of atleast 5 seconds. So
+  # we need to sleep for an equivalent amount of time to ensure state from a
+  # previous test is cleared up and old (non-existent) devices have been removed
+  # from the ResourceSlice. This seems to only be an an issue of the test where
+  # we create "dummy" interfaces which disappear if the network namespace is
+  # deleted.
+  sleep 5
 }
 
 dump_debug_info_on_failure() {


### PR DESCRIPTION
The driver is rate limited to updates with interval of atleast 5 seconds: 
https://github.com/google/dranet/blob/5f2c3777fe6e3f8c55c3f17efebafd976b70a306/pkg/inventory/db.go#L46
https://github.com/google/dranet/blob/5f2c3777fe6e3f8c55c3f17efebafd976b70a306/pkg/inventory/db.go#L128

So we need to sleep for an equivalent amount of time to ensure state from a previous test is cleared up and old (non-existent) devices have been removed from the ResourceSlice. This seems to only be an an issue of the test where we create "dummy" interfaces which disappear if the network namespace is deleted.

We were previously sleeping for 5 seconds but that was changed in https://github.com/google/dranet/pull/208 to 2 seconds which is causing flakes like https://github.com/google/dranet/actions/runs/17281340446/job/49050151995
