### PR TITLE
refactor: Remove redundant rate limit in PublishResources

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -75,8 +75,6 @@ func (np *NetworkDriver) PublishResources(ctx context.Context) {
 			klog.Error(ctx.Err(), "context canceled")
 			return
 		}
-		// poor man rate limit
-		time.Sleep(3 * time.Second)
 	}
 }
 


### PR DESCRIPTION
The device discovery process in `pkg/inventory/db.go` (producer) uses a rate limiter to control how frequently it scans for hardware changes and reports them as notifications (to the consumer). https://github.com/google/dranet/blob/51b8a6c076120a0b28dbca872ad003d64af978b8/pkg/inventory/db.go#L128 This effectively rate-limits the entire resource publishing pipeline at its source.

At the moment, there is no need for these two to have separate individual rate limits. 